### PR TITLE
Configuration supports environment variables

### DIFF
--- a/app/coin/protocol/coin.go
+++ b/app/coin/protocol/coin.go
@@ -218,9 +218,6 @@ func (c *Coin) GetAccountTransactions(peerID []byte) ([]*pb.Transaction, error) 
 			return nil, err
 		}
 		transactions[i] = blk.GetTransactions()[txKey.TxIdx]
-		if err != nil {
-			return nil, err
-		}
 	}
 	return transactions, nil
 }

--- a/app/raft/protocol/net.go
+++ b/app/raft/protocol/net.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stratumn/go-node/app/raft/pb"
 
-	peer "github.com/libp2p/go-libp2p-peer"
 	logging "github.com/ipfs/go-log"
-	inet "github.com/libp2p/go-libp2p-net"
-	protocol "github.com/libp2p/go-libp2p-protocol"
 	ihost "github.com/libp2p/go-libp2p-host"
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+	protocol "github.com/libp2p/go-libp2p-protocol"
 	protobuf "github.com/multiformats/go-multicodec/protobuf"
 )
 
@@ -164,11 +164,6 @@ func (n *netProcess) circleClient(ctx context.Context, msgCircle pb.Internode) {
 	defer n.closeStream(stream)
 
 	enc := protobuf.Multicodec(nil).Encoder(stream)
-	if err != nil {
-		n.errorChan <- errors.WithStack(err)
-		return
-	}
-
 	err = enc.Encode(&msgCircle)
 	if err != nil {
 		n.errorChan <- errors.WithStack(err)

--- a/cli/reflect.go
+++ b/cli/reflect.go
@@ -1,4 +1,4 @@
-// Copyright © 2017-2018 Stratumn SAS
+  // Copyright © 2017-2018 Stratumn SAS
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -778,10 +778,7 @@ func (r ServerReflector) getServiceDescs(c *grpcreflect.Client, servNames []stri
 
 		d, err := c.ResolveService(name)
 		if err != nil {
-			if err != nil {
-				r.cons.Warningf("Could not get service descriptor for %q: %s\n", name, err)
-				continue
-			}
+			r.cons.Warningf("Could not get service descriptor for %q: %s\n", name, err)
 			continue
 		}
 

--- a/core/cfg/cfg.go
+++ b/core/cfg/cfg.go
@@ -249,17 +249,23 @@ func (s Set) fromEnv(ctx context.Context) error {
 			case reflect.String:
 				newCfgField.Set(reflect.ValueOf(valueFromEnvironment))
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-				convertedVal, err := strconv.Atoi(valueFromEnvironment)
+				convertedVal, err := strconv.ParseInt(valueFromEnvironment, 10, 0)
 				if err != nil {
 					return err
 				}
-				newCfgField.SetInt(int64(convertedVal))
+				newCfgField.SetInt(convertedVal)
 			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 				convertedVal, err := strconv.ParseUint(valueFromEnvironment, 10, 0)
 				if err != nil {
 					return err
 				}
-				newCfgField.SetUint(uint64(convertedVal))
+				newCfgField.SetUint(convertedVal)
+			case reflect.Float32, reflect.Float64:
+				convertedVal, err := strconv.ParseFloat(valueFromEnvironment, 0)
+				if err != nil {
+					return err
+				}
+				newCfgField.SetFloat(convertedVal)
 			case reflect.Bool:
 				convertedVal, err := strconv.ParseBool(valueFromEnvironment)
 				if err != nil {

--- a/core/cfg/cfg.go
+++ b/core/cfg/cfg.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 
 	logging "github.com/ipfs/go-log"
 )
@@ -98,6 +99,11 @@ func (s Set) Load(filename string) error {
 	}
 
 	if err := s.fromTree(ctx, tree); err != nil {
+		event.SetError(err)
+		return err
+	}
+
+	if err := s.fromEnv(ctx); err != nil {
 		event.SetError(err)
 		return err
 	}
@@ -175,7 +181,7 @@ func (s Set) Set(key string, value string) error {
 	return s.fromTree(context.Background(), tree.tree)
 }
 
-// setValuesFromTree sets the values of a set from a TOML tree.
+// fromTree sets the values of a set from a TOML tree.
 func (s Set) fromTree(ctx context.Context, tree *toml.Tree) error {
 	structuredSet := structuralize(ctx, s.Configs())
 
@@ -194,6 +200,80 @@ func (s Set) fromTree(ctx context.Context, tree *toml.Tree) error {
 		}
 
 		if err := configurable.SetConfig(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// fromEnv sets the values of a set from environment variables.
+// Environment variables must use UPPER_SNAKE_CASE and prefixed by the name of the service.
+// It uses the same tag as toml to avoid having multiple tags.
+// eg: in order to set myservice.custom_setting, the env variable MYSERVICE_CUSTOM_SETTING should be provided.
+func (s Set) fromEnv(ctx context.Context) error {
+	v := viper.New()
+	v.AutomaticEnv()
+
+	for id, cfg := range s.Configs() {
+		v.SetEnvPrefix(id)
+
+		// use reflection to introspect the type and the value of the configuration.
+		cfgType := reflect.TypeOf(cfg)
+		currentCfg := reflect.ValueOf(cfg)
+
+		// create a new configuration object.
+		newCfg := reflect.New(cfgType).Elem()
+
+		// iterate over the configuration struct fields.
+		for i := 0; i < cfgType.NumField(); i++ {
+			currentCfgField := currentCfg.Field(i)
+			newCfgField := newCfg.Field(i)
+			envVar := cfgType.Field(i).Tag.Get("toml")
+
+			// if the "toml" tag was not specified on this field, use the current configuration.
+			if envVar == "" {
+				newCfgField.Set(currentCfgField)
+				continue
+			}
+
+			valueFromEnvironment := v.GetString(envVar)
+			// if the environment variable is not set, use the current configuration.
+			if valueFromEnvironment == "" {
+				newCfgField.Set(currentCfgField)
+				continue
+			}
+
+			// convert the environment variable to the correct type.
+			switch t := cfgType.Field(i).Type.Kind(); t {
+			case reflect.String:
+				newCfgField.Set(reflect.ValueOf(valueFromEnvironment))
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				convertedVal, err := strconv.Atoi(valueFromEnvironment)
+				if err != nil {
+					return err
+				}
+				newCfgField.SetInt(int64(convertedVal))
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				convertedVal, err := strconv.ParseUint(valueFromEnvironment, 10, 0)
+				if err != nil {
+					return err
+				}
+				newCfgField.SetUint(uint64(convertedVal))
+			case reflect.Bool:
+				convertedVal, err := strconv.ParseBool(valueFromEnvironment)
+				if err != nil {
+					return err
+				}
+				newCfgField.SetBool(convertedVal)
+			default:
+				return errors.Errorf("could not parse env var %s: unhandled type %s", strings.ToUpper(id+"_"+envVar), t.String())
+			}
+		}
+
+		// set the updated configuration.
+		err := s[id].SetConfig(newCfg.Interface())
+		if err != nil {
 			return err
 		}
 	}

--- a/core/cfg/cfg_test.go
+++ b/core/cfg/cfg_test.go
@@ -118,17 +118,17 @@ func TestCfg(t *testing.T) {
 			defer os.Unsetenv("ZIP_AUTHOR")
 			os.Setenv("ZIP_STARTED", "true")
 			defer os.Unsetenv("ZIP_AUTHOR")
-			os.Setenv("ZIP_SIZE", "28")
+			os.Setenv("TAR_SIZE", "28")
 			defer os.Unsetenv("ZIP_SIZE")
-			os.Setenv("ZIP_RATIO", "9.09876")
+			os.Setenv("TAR_RATIO", "9.09876")
 			defer os.Unsetenv("ZIP_SIZE")
 
 			err = setLoad.Load(filename)
 			require.NoError(t, err, "Load(filename)")
 			assert.Equal(t, author, zipLoad.author)
 			assert.Equal(t, true, zipLoad.started)
-			assert.Equal(t, 28, zipLoad.size)
-			assert.Equal(t, 9.09876, zipLoad.ratio)
+			assert.Equal(t, 28, tarLoad.size)
+			assert.Equal(t, 9.09876, tarLoad.ratio)
 		})
 
 		t.Run("Fails if type is not supported by env var", func(t *testing.T) {

--- a/core/cfg/cfg_test.go
+++ b/core/cfg/cfg_test.go
@@ -33,6 +33,7 @@ type testConfig struct {
 	Started     bool     `toml:"started"`
 	Author      string   `toml:"author"`
 	Size        int      `toml:"size"`
+	Ratio       float64  `toml:"ratio"`
 	StringStuff []string `toml:"string_stuff"`
 	IntStuff    []int    `toml:"int_stuff"`
 }
@@ -44,6 +45,7 @@ type testHandler struct {
 	started     bool
 	author      string
 	size        int
+	ratio       float64
 	stringStuff []string
 	intStuff    []int
 }
@@ -57,7 +59,7 @@ func (h *testHandler) Config() interface{} {
 		return *h.config
 	}
 
-	return testConfig{h.name, h.version, h.started, h.author, h.size, h.stringStuff, h.intStuff}
+	return testConfig{h.name, h.version, h.started, h.author, h.size, h.ratio, h.stringStuff, h.intStuff}
 }
 
 func (h *testHandler) SetConfig(config interface{}) error {
@@ -70,6 +72,7 @@ func (h *testHandler) SetConfig(config interface{}) error {
 	h.intStuff = c.IntStuff
 	h.author = c.Author
 	h.size = c.Size
+	h.ratio = c.Ratio
 	return nil
 }
 
@@ -117,12 +120,15 @@ func TestCfg(t *testing.T) {
 			defer os.Unsetenv("ZIP_AUTHOR")
 			os.Setenv("ZIP_SIZE", "28")
 			defer os.Unsetenv("ZIP_SIZE")
+			os.Setenv("ZIP_RATIO", "9.09876")
+			defer os.Unsetenv("ZIP_SIZE")
 
 			err = setLoad.Load(filename)
 			require.NoError(t, err, "Load(filename)")
 			assert.Equal(t, author, zipLoad.author)
 			assert.Equal(t, true, zipLoad.started)
 			assert.Equal(t, 28, zipLoad.size)
+			assert.Equal(t, 9.09876, zipLoad.ratio)
 		})
 
 		t.Run("Fails if type is not supported by env var", func(t *testing.T) {

--- a/core/cfg/cfg_test.go
+++ b/core/cfg/cfg_test.go
@@ -17,6 +17,7 @@ package cfg
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -31,6 +32,7 @@ type testConfig struct {
 	Version     int      `toml:"version"`
 	Started     bool     `toml:"started"`
 	Author      string   `toml:"author"`
+	Size        int      `toml:"size"`
 	StringStuff []string `toml:"string_stuff"`
 	IntStuff    []int    `toml:"int_stuff"`
 }
@@ -41,6 +43,7 @@ type testHandler struct {
 	version     int
 	started     bool
 	author      string
+	size        int
 	stringStuff []string
 	intStuff    []int
 }
@@ -54,7 +57,7 @@ func (h *testHandler) Config() interface{} {
 		return *h.config
 	}
 
-	return testConfig{h.name, h.version, h.started, h.author, h.stringStuff, h.intStuff}
+	return testConfig{h.name, h.version, h.started, h.author, h.size, h.stringStuff, h.intStuff}
 }
 
 func (h *testHandler) SetConfig(config interface{}) error {
@@ -66,6 +69,7 @@ func (h *testHandler) SetConfig(config interface{}) error {
 	h.stringStuff = c.StringStuff
 	h.intStuff = c.IntStuff
 	h.author = c.Author
+	h.size = c.Size
 	return nil
 }
 
@@ -92,16 +96,44 @@ func TestCfg(t *testing.T) {
 	})
 	require.NoError(t, err, "Save(filename)")
 
-	zipLoad := testHandler{name: zipHandlerName, version: 1}
-	tarLoad := testHandler{name: tarHandlerName, version: 1}
-	setLoad := NewSet([]Configurable{&zipLoad, &tarLoad})
+	t.Run("Load", func(t *testing.T) {
 
-	err = setLoad.Load(filename)
-	require.NoError(t, err, "Load(filename)")
+		zipLoad := testHandler{name: zipHandlerName, version: 1}
+		tarLoad := testHandler{name: tarHandlerName, version: 1}
+		setLoad := NewSet([]Configurable{&zipLoad, &tarLoad})
 
-	assert.Equal(t, zipSave.version, zipLoad.version, "zipLoad")
-	assert.Equal(t, zipSave.intStuff, zipLoad.intStuff, "zipLoad")
-	assert.Equal(t, tarSave.version, tarLoad.version, "tarLoad")
+		err = setLoad.Load(filename)
+		require.NoError(t, err, "Load(filename)")
+
+		assert.Equal(t, zipSave.version, zipLoad.version, "zipLoad")
+		assert.Equal(t, zipSave.intStuff, zipLoad.intStuff, "zipLoad")
+		assert.Equal(t, tarSave.version, tarLoad.version, "tarLoad")
+
+		t.Run("Environment variables override values", func(t *testing.T) {
+			author := "chewbacca"
+			os.Setenv("ZIP_AUTHOR", author)
+			defer os.Unsetenv("ZIP_AUTHOR")
+			os.Setenv("ZIP_STARTED", "true")
+			defer os.Unsetenv("ZIP_AUTHOR")
+			os.Setenv("ZIP_SIZE", "28")
+			defer os.Unsetenv("ZIP_SIZE")
+
+			err = setLoad.Load(filename)
+			require.NoError(t, err, "Load(filename)")
+			assert.Equal(t, author, zipLoad.author)
+			assert.Equal(t, true, zipLoad.started)
+			assert.Equal(t, 28, zipLoad.size)
+		})
+
+		t.Run("Fails if type is not supported by env var", func(t *testing.T) {
+			os.Setenv("ZIP_INT_STUFF", "[1, 2, 3]")
+			defer os.Unsetenv("ZIP_INT_STUFF")
+
+			err = setLoad.Load(filename)
+			require.EqualError(t, err, "could not parse env var ZIP_INT_STUFF: unhandled type slice")
+		})
+
+	})
 
 	t.Run("Save", func(t *testing.T) {
 		files, err := ioutil.ReadDir(dir)

--- a/core/cfg/migrate.go
+++ b/core/cfg/migrate.go
@@ -137,6 +137,11 @@ func Migrate(
 		return err
 	}
 
+	if err := set.fromEnv(ctx); err != nil {
+		event.SetError(err)
+		return err
+	}
+
 	if !updated {
 		return nil
 	}

--- a/doc/services.md
+++ b/doc/services.md
@@ -109,3 +109,9 @@ pruner   RUNNING  [manager]        false      true      Service Pruner   Prunes 
 signal   RUNNING  [manager]        false      true      Signal Handler   Handles exit signals.
 system   RUNNING  [pruner signal]  false      true      System Services  Starts system services.
 ```
+
+## Configuration
+
+Each service can be configured through the `core` TOML configuration file, therefore the `Config` object of your service must be annotated the "toml" flag.
+
+Configuration variables can be overriden using environment variables. These should be prefixed by the service name and use UPPER_SNAKE_CASE. For instance, if you want to override the variable `custom_setting` of `testservice`, the environment variable `TESTSERVICE_CUSTOM_SETTING=something` should be provided.


### PR DESCRIPTION
This PR adds support for environment variables in the configuration. It uses reflection to find the matching settings in the configuration and I tried to document the code as much as I could (because reflection is not self-explanatory).

Env variables override the configuration defined in the file, but I could make it optional if you think we want to avoid this behaviour in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-node/324)
<!-- Reviewable:end -->
